### PR TITLE
fix: `make build` failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
-GO111MODULE=off
-GOARCH=amd64
-GOOS=darwin
-# GOOS=linux
+GO111MODULE ?= on
+GOARCH ?= $(shell go env GOARCH)
+GOOS ?= $(shell go env GOOS)
 GO_PACKAGE=github.com/alibaba/open-simulator
 CGO_ENABLED=0
 
@@ -17,8 +16,8 @@ all: build
 .PHONY: build 
 build:
 	GO111MODULE=$(GO111MODULE) GOARCH=$(GOARCH) GOOS=$(GOOS) CGO_ENABLED=0 go build -trimpath $(LD_FLAGS) -v -o $(OUTPUT_DIR)/$(BINARY_NAME) ./cmd
-	# chmod +x $(OUTPUT_DIR)/$(BINARY_NAME)
-	# bin/simon apply -i -f ./example/simon-config.yaml
+# chmod +x $(OUTPUT_DIR)/$(BINARY_NAME)
+# bin/simon apply -i -f ./example/simon-config.yaml
 
 .PHONY: test 
 test:


### PR DESCRIPTION
Fix `make build` failed:

```sh
✗  make build
GO111MODULE=off GOARCH= GOOS= CGO_ENABLED=0 go build -trimpath -ldflags "-X 'github.com/alibaba/open-simulator/cmd/version.VERSION=dev' -X 'github.com/alibaba/open-simulator/cmd/version.COMMITID=09b779c'" -v -o ./bin/simon ./cmd
cmd/main.go:6:2: cannot find package "github.com/alibaba/open-simulator/cmd/simon" in any of:
	/usr/local/go/src/github.com/alibaba/open-simulator/cmd/simon (from $GOROOT)
	/Users/thearas/go/src/github.com/alibaba/open-simulator/cmd/simon (from $GOPATH)
cmd/main.go:7:2: cannot find package "github.com/pterm/pterm" in any of:
	/usr/local/go/src/github.com/pterm/pterm (from $GOROOT)
	/Users/thearas/go/src/github.com/pterm/pterm (from $GOPATH)
make: *** [build] Error 1
```